### PR TITLE
Inline spc import, makes specio pip installable without spc

### DIFF
--- a/specio/plugins/spc.py
+++ b/specio/plugins/spc.py
@@ -11,13 +11,12 @@ import warnings
 
 import numpy as np
 
-import spc
-
 from .. import formats
 from ..core import Format
 from ..core.exceptions import VersionError
 from ..core.request import read_n_bytes
 from ..core.util import Spectrum
+
 
 VERSION_SUPPORTED = (b'\x4b', b'\x4d', b'\xcf')
 
@@ -207,6 +206,7 @@ class SPC(Format):
             return Spectrum(spectrum, wavelength, meta)
 
         def _open(self):
+            import spc
             # Open the reader
             self._fp = self.request.get_local_filename()
             self._data = self._spc_to_numpy(spc.File(self._fp))


### PR DESCRIPTION
A bit easier than working with a global constant etc, as there was only one use of spc. This makes you can import specio for now without having spc:

```
In [1]: import specio

In [2]: from specio.datasets import load_spc_path

In [3]: specio.specread(load_spc_path())
...
ImportError: No module named 'spc'
```

I suppose the error message could be improved with saying that "this format needs this package .." (but since we probably are going to vendor it? maybe not worth now)